### PR TITLE
Change CurrencyInput's inputMode to "decimal"

### DIFF
--- a/app/javascript/components/shared/CurrencyInput.jsx
+++ b/app/javascript/components/shared/CurrencyInput.jsx
@@ -37,7 +37,7 @@ class CurrencyInput extends React.Component {
     return (
       <MaskedInput
         placeholder="$0.00"
-        inputMode="numeric"
+        inputMode="decimal"
         mask={currencyMask}
         onBlur={this.handleBlur}
         onChange={this.handleChange}


### PR DESCRIPTION
This will allow mobile devices (e.g. Safari, etc) to see a numeric input, but include the decimal place. Without this mode change, the decimal is not visible in the input on Safari iOS--only numbers are shown so there was no way to add cents.

From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode):
> `decimal`
>     Fractional numeric input keyboard containing the digits and decimal separator for the user's locale (typically . or ,). Devices may or may not show a minus key (-).
> `numeric`
>     Numeric input keyboard, but only requires the digits 0–9. Devices may or may not show a minus key.


![image](https://user-images.githubusercontent.com/149965/89908288-b2999b80-dbbb-11ea-8abc-397dd3cd786b.png)
