### PR TITLE
Allow setup scripts to use different ruby version managers

### DIFF
--- a/scripts.sh
+++ b/scripts.sh
@@ -24,16 +24,16 @@ setup_db () {
 }
 
 set_ruby_version () {
-  if [[ $(ruby -v) =~ "2.6.5" ]]
+  if [[ $(ruby -v) =~ "$(cat .ruby-version)" ]]
   then
-    echo "You are on Ruby 2.6.5"
+    echo "You are the preferred Ruby version: $(cat .ruby-version)"
   else
     if [[ $(which rbenv) ]]
     then
       eval "$(rbenv init -)"
     elif [[ $(which rvm) ]]
     then
-      rvm 2.6.5
+      rvm $(cat .ruby-version)
     elif [[ $(which chruby) ]]
     then
       chruby $(cat .ruby-version)

--- a/scripts.sh
+++ b/scripts.sh
@@ -1,37 +1,68 @@
 #!/bin/bash
-install_rails () {
-	echo "INSTALLING BUNDLER"
-	gem install bundler
+install_dependencies () {
+  if [[ $(which bundle) ]]
+  then
+    echo "INSTALLING GEMS"
+	  bundle install
+	  echo "INSTALLING JS PACKAGES"
+	  yarn install
+  else
+    echo "INSTALLING BUNDLER"
+    gem install bundler
+    echo "INSTALLING GEMS"
+	  bundle install
+	  echo "INSTALLING JS PACKAGES"
+	  yarn install
+  fi
+}
+
+setup_db () {
 	echo "CREATING DATABASE"
 	bundle exec rake db:create
+  echo "MIGRATING DATABASE"
+  bundle exec rake db:migrate
+}
+
+set_ruby_version () {
+  if [[ $(ruby -v) =~ "2.6.5" ]]
+  then
+    echo "You are on Ruby 2.6.5"
+  else
+    if [[ $(which rbenv) ]]
+    then
+      eval "$(rbenv init -)"
+    elif [[ $(which rvm) ]]
+    then
+      rvm 2.6.5
+    elif [[ $(which chruby) ]]
+    then
+      chruby $(cat .ruby-version)
+    fi
+  fi
+
 }
 
 start_server () {
 	echo "INITIALIZING RUBY VERSION MANAGER"
-	eval "$(rbenv init -)"
-	echo "INSTALLING GEMS"
-	bundle install
-	echo "INSTALLING JS PACKAGES"
-	yarn install
-	echo "ENSURING DATABASE IS MIGRATED"
-	bundle exec rake db:migrate
+	set_ruby_version
+	echo "INSTALLING DEPENDENCIES"
+  install_dependencies
+  echo "SETTING UP DATABASE"
+  setup_db
 	echo "STARTING SERVER AT PORT 3000"
 	bundle exec rails s
 }
 
-if [ "$1" == "start" ]
+if [[ "$1" == "start" ]]
 then
 	start_server
-fi
-
-if [ "$1" == "install_with_brew" ]
+elif [[ "$1" == "install_with_brew" ]]
 then
 	echo "INSTALLING RUBY VERSION MANAGER"
 	brew install rbenv ruby-build || (echo "brew install rbenv ruby-build failed - continuing")
 	echo "INITIALIZING RUBY VERSION MANAGER"
 	eval "$(rbenv init -)"
 	rbenv install 2.6.5 || (echo "ruby install failed - continuing")
-	install_rails
 	start_server
 fi
 

--- a/scripts.sh
+++ b/scripts.sh
@@ -1,44 +1,44 @@
 #!/bin/bash
 install_dependencies () {
-  if [[ $(which bundle) ]]
-  then
-    echo "INSTALLING GEMS"
-	  bundle install
-	  echo "INSTALLING JS PACKAGES"
-	  yarn install
-  else
-    echo "INSTALLING BUNDLER"
-    gem install bundler
-    echo "INSTALLING GEMS"
-	  bundle install
-	  echo "INSTALLING JS PACKAGES"
-	  yarn install
-  fi
+	if [[ $(which bundle) ]]
+	then
+		echo "INSTALLING GEMS"
+		bundle install
+		echo "INSTALLING JS PACKAGES"
+		yarn install
+	else
+		echo "INSTALLING BUNDLER"
+		gem install bundler
+		echo "INSTALLING GEMS"
+		bundle install
+		echo "INSTALLING JS PACKAGES"
+		yarn install
+	fi
 }
 
 setup_db () {
 	echo "CREATING DATABASE"
 	bundle exec rake db:create
-  echo "MIGRATING DATABASE"
-  bundle exec rake db:migrate
+	echo "MIGRATING DATABASE"
+	bundle exec rake db:migrate
 }
 
 set_ruby_version () {
-  if [[ $(ruby -v) =~ "$(cat .ruby-version)" ]]
-  then
-    echo "You are the preferred Ruby version: $(cat .ruby-version)"
-  else
-    if [[ $(which rbenv) ]]
-    then
-      eval "$(rbenv init -)"
-    elif [[ $(which rvm) ]]
-    then
-      rvm $(cat .ruby-version)
-    elif [[ $(which chruby) ]]
-    then
-      chruby $(cat .ruby-version)
-    fi
-  fi
+	if [[ $(ruby -v) =~ "$(cat .ruby-version)" ]]
+	then
+		echo "You are the preferred Ruby version: $(cat .ruby-version)"
+	else
+		if [[ $(which rbenv) ]]
+		then
+			eval "$(rbenv init -)"
+		elif [[ $(which rvm) ]]
+		then
+			rvm $(cat .ruby-version)
+		elif [[ $(which chruby) ]]
+		then
+			chruby $(cat .ruby-version)
+		fi
+	fi
 
 }
 
@@ -46,9 +46,9 @@ start_server () {
 	echo "INITIALIZING RUBY VERSION MANAGER"
 	set_ruby_version
 	echo "INSTALLING DEPENDENCIES"
-  install_dependencies
-  echo "SETTING UP DATABASE"
-  setup_db
+	install_dependencies
+	echo "SETTING UP DATABASE"
+	setup_db
 	echo "STARTING SERVER AT PORT 3000"
 	bundle exec rails s
 }


### PR DESCRIPTION
Hi @inoda, I dig ontrack, but I ran into some hangups starting it locally, and wanted to propose a few changes to the startup script. 

My main issue was it would assume I had `rbenv` installed when I use `chruby`. So I added some logic to check for rbenv, rvm, or chruby, and use the appropriate command. The exact version is pulled from the `.ruby-version` file so it'll be dynamic.

I also moved the actions related the database into their own function. And the dependency related actions into their own function. I thought this read a little cleaner.

Since I was doing more than just checking strings I used `[[ ]]` for the conditionals, which should work since this script requests bash, but if that's a concern I can rework it.