### PR TITLE
Category modal: Allow all colors to be shown

### DIFF
--- a/app/assets/stylesheets/color_picker.scss
+++ b/app/assets/stylesheets/color_picker.scss
@@ -1,4 +1,6 @@
 .color-picker {
+  max-width: 210px;
+
   .sample {
     height: 30px;
     width: 30px;

--- a/app/javascript/components/categories/FormModal.jsx
+++ b/app/javascript/components/categories/FormModal.jsx
@@ -78,10 +78,8 @@ class FormModal extends React.Component {
 
             <div className="input-group ml-auto">
               <label className="required">Color</label>
-              <ColorPicker onChange={this.handleColorChange} initialColor={this.state.color} omitColors={this.props.colorsToSkip} colorsToShow={5} />
+              <ColorPicker onChange={this.handleColorChange} initialColor={this.state.color} omitColors={this.props.colorsToSkip} />
             </div>
-
-            <div className="clearfix"></div>
           </div>
 
           <div className="row">

--- a/app/javascript/components/shared/ColorPicker.jsx
+++ b/app/javascript/components/shared/ColorPicker.jsx
@@ -26,7 +26,7 @@ class ColorPicker extends React.Component {
     let availColors = []
     if (this.state.initialColor.length) { availColors.push(this.state.initialColor); }
     for (let color of allColors) {
-      if (availColors.length == this.props.colorsToShow) { break; }
+      if (this.props.colorsToShow && this.props.colorsToShow === availColors.length) { break; }
       if (availColors.map((el) => { return el.toLowerCase() }).includes(color.toLowerCase())) { continue; }
       if (this.props.omitColors.length && this.props.omitColors.map((el) => { return el.toLowerCase() }).includes(color.toLowerCase())) { continue;}
       availColors.push(color);
@@ -54,7 +54,6 @@ ColorPicker.defaultProps = {
   colors: [],
   omitColors: [],
   initialColor: '',
-  colorsToShow: 8,
 }
 
 ColorPicker.propTypes = {


### PR DESCRIPTION
I wanted to see more colors for my categories. I already had some colors in mind, for example, I use brown color for "Coffee" category. With the "old" implementation, it wasn't possible for me to always choose brown color. I've added a small change that always shows all of the (remaining) available colors.

Here's how it looks:
<img width="480" alt="Screen Shot 2020-10-01 at 10 55 42" src="https://user-images.githubusercontent.com/67437/94789280-01ea9400-03d5-11eb-9ae4-f4e5d63c8b0b.png">

Here's how it looks on mobile:
<img width="480" src="https://user-images.githubusercontent.com/67437/94789421-2e061500-03d5-11eb-8da6-c2070b1dfdbb.jpg">

Ideally, there should also be a color picker where user can choose any color they want.