### PR TITLE
Add missing dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.15.0",
     "@babel/preset-env": "^7.15.4",
+    "babel-plugin-macros": "^3.0.1",
     "@rails/actioncable": "^6.0.3-2",
     "@rails/activestorage": "^6.0.3-2",
     "@rails/ujs": "^6.0.3-2",


### PR DESCRIPTION
This PR is related to the #74 missing dependency error. I simply added the babel-plugin-macros to the package.json file.

Tested with the provided docker-compose.yml setup.